### PR TITLE
Add cdylib options that can replace unix-weak-link feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,15 +98,15 @@ jobs:
       - name: Build and Test Tracer
         run: |
           cd plugins/tracer
-          cargo build -r --features=plugin-api-v${{ matrix.version }} --no-default-features || exit 0
-          cargo build -r --features=plugin-api-v${{ matrix.version }} --no-default-features
-          cargo run --features=plugin-api-v${{ matrix.version }} --no-default-features -r --bin tracer -- -a /bin/ls -- -lah
+          cargo build -r --features=plugin-api-v${{ matrix.version }},unix-weak-link --no-default-features || exit 0
+          cargo build -r --features=plugin-api-v${{ matrix.version }},unix-weak-link --no-default-features
+          cargo run --features=plugin-api-v${{ matrix.version }},unix-weak-link --no-default-features -r --bin tracer -- -a /bin/ls -- -lah
           cd ../..
 
       - name: Build and Test Tiny
         run: |
           cd plugins/tiny
-          cargo build -r --features=plugin-api-v${{ matrix.version }} --no-default-features
+          cargo build -r --features=plugin-api-v${{ matrix.version }},unix-weak-link --no-default-features
           qemu-x86_64 -plugin ../../target/release/libtiny.so /bin/ls -lah
           cd ../..
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
     name: Build and Test Plugins (Windows)
     runs-on: windows-latest
     env:
-      QEMU_VERSION: 9.2.3-1
+      QEMU_VERSION: 10.0.0-2
       RUSTUP_URL: "https://win.rustup.rs/x86_64"
       FEDORA_CLOUDIMG_URL: "https://download.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,106 @@ jobs:
           qemu-x86_64 -plugin ../../target/release/libtiny.so /bin/ls -lah
           cd ../..
 
+  test_plugins_linux_stable:
+    name: Build and Test Plugins API v${{ matrix.version }} (Linux, stable Rust)
+    runs-on: ubuntu-latest
+    container: ubuntu:24.04
+    strategy:
+      matrix:
+        include:
+          - version: 1
+            commit: fb691b8cbabf5bde7d25a7f720d5ec7d5b1341e1
+          - version: 2
+            commit: fba3b490a26cb278dfa183d7fcc375746e312980
+          - version: 3
+            commit: 7de77d37880d7267a491cb32a1b2232017d1e545
+          - version: 4
+            commit: cfa3a6c54511374e9ccee26d9c38ac1698fc7af2
+    env:
+      QEMU_COMMIT_HASH: ${{ matrix.commit }}
+    steps:
+      - name: Set up Sources List
+        run: |
+          cat <<EOF > /etc/apt/sources.list.d/ubuntu.sources
+          Types: deb
+          URIs: http://archive.ubuntu.com/ubuntu/
+          Suites: noble noble-updates noble-backports
+          Components: main universe restricted multiverse
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+          Types: deb
+          URIs: http://security.ubuntu.com/ubuntu/
+          Suites: noble-security
+          Components: main universe restricted multiverse
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+          Types: deb-src
+          URIs: http://archive.ubuntu.com/ubuntu/
+          Suites: noble noble-updates noble-backports
+          Components: main universe restricted multiverse
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+          Types: deb
+          URIs: http://security.ubuntu.com/ubuntu/
+          Suites: noble-security
+          Components: main universe restricted multiverse
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          EOF
+
+      - name: Install QEMU Build Dependencies
+        run: |
+          apt -y update
+          apt -y install git curl build-essential
+          apt -y source qemu
+          apt -y build-dep qemu
+
+      - name: Cache QEMU
+        id: qemu-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            qemu-upstream
+          key: ${{ runner.os }}-qemu-v${{ matrix.version }}-${{ matrix.commit }}
+
+      - name: Clone QEMU
+        if: steps.qemu-cache.outputs.cache-hit != 'true'
+        run: |
+          git clone https://gitlab.com/qemu/qemu qemu-upstream
+          cd qemu-upstream
+          git checkout "${QEMU_COMMIT_HASH}"
+
+      - name: Build QEMU
+        if: steps.qemu-cache.outputs.cache-hit != 'true'
+        run: |
+          cd qemu-upstream
+          ./configure --enable-plugins
+          cd build
+          make -j$(nproc)
+          make install
+          cd ../..
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v4
+
+      - name: Test QEMU Install
+        run: |
+          qemu-x86_64 --help
+
+      - name: Build and Test Tracer
+        run: |
+          cd plugins/tracer
+          cargo build -r --features=plugin-api-v${{ matrix.version }} --no-default-features || exit 0
+          cargo build -r --features=plugin-api-v${{ matrix.version }} --no-default-features
+          cargo run --features=plugin-api-v${{ matrix.version }} --no-default-features -r --bin tracer -- -a /bin/ls -- -lah
+          cd ../..
+
+      - name: Build and Test Tiny
+        run: |
+          cd plugins/tiny
+          cargo build -r --features=plugin-api-v${{ matrix.version }} --no-default-features
+          qemu-x86_64 -plugin ../../target/release/libtiny.so /bin/ls -lah
+          cd ../..
+
   test_plugins_windows:
     name: Build and Test Plugins (Windows)
     runs-on: windows-latest

--- a/plugins/tiny-system/Cargo.toml
+++ b/plugins/tiny-system/Cargo.toml
@@ -7,9 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-qemu-plugin = { workspace = true, features = [
-    "unix-weak-link",
-], default-features = false }
+qemu-plugin = { workspace = true, default-features = false }
 anyhow = "1.0.94"
 ffi = "0.1.1"
 ctor = "0.2.9"
@@ -20,3 +18,4 @@ plugin-api-v1 = ["qemu-plugin/plugin-api-v1"]
 plugin-api-v2 = ["qemu-plugin/plugin-api-v2"]
 plugin-api-v3 = ["qemu-plugin/plugin-api-v3"]
 plugin-api-v4 = ["qemu-plugin/plugin-api-v4"]
+unix-weak-link = ["qemu-plugin/unix-weak-link"]

--- a/plugins/tiny/Cargo.toml
+++ b/plugins/tiny/Cargo.toml
@@ -7,9 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-qemu-plugin = { workspace = true, features = [
-    "unix-weak-link",
-], default-features = false }
+qemu-plugin = { workspace = true, default-features = false }
 anyhow = "1.0.94"
 ffi = "0.1.1"
 ctor = "0.2.9"
@@ -20,3 +18,4 @@ plugin-api-v1 = ["qemu-plugin/plugin-api-v1"]
 plugin-api-v2 = ["qemu-plugin/plugin-api-v2"]
 plugin-api-v3 = ["qemu-plugin/plugin-api-v3"]
 plugin-api-v4 = ["qemu-plugin/plugin-api-v4"]
+unix-weak-link = ["qemu-plugin/unix-weak-link"]

--- a/plugins/tracer/Cargo.toml
+++ b/plugins/tracer/Cargo.toml
@@ -10,9 +10,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 anyhow = "1.0.94"
 ctor = "0.2.9"
-qemu-plugin = { workspace = true, features = [
-    "unix-weak-link",
-], default-features = false }
+qemu-plugin = { workspace = true, default-features = false }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_cbor = "0.11.2"
 tokio = { version = "1.42.0", features = ["full"] }
@@ -32,3 +30,4 @@ plugin-api-v1 = ["qemu-plugin/plugin-api-v1"]
 plugin-api-v2 = ["qemu-plugin/plugin-api-v2"]
 plugin-api-v3 = ["qemu-plugin/plugin-api-v3"]
 plugin-api-v4 = ["qemu-plugin/plugin-api-v4"]
+unix-weak-link = ["qemu-plugin/unix-weak-link"]

--- a/qemu-plugin-sys/build.rs
+++ b/qemu-plugin-sys/build.rs
@@ -44,5 +44,16 @@ fn main() -> Result<()> {
         println!("cargo:rustc-link-lib=qemu_plugin_api");
     }
 
+    #[cfg(target_os = "macos")]
+    {
+        println!("cargo::rustc-cdylib-link-arg=-undefined");
+        println!("cargo::rustc-cdylib-link-arg=dynamic_lookup");
+    }
+
+    #[cfg(all(target_family = "unix", not(target_os = "macos")))]
+    {
+        println!("cargo::rustc-cdylib-link-arg=-Wl,-z,undefs");
+    }
+
     Ok(())
 }


### PR DESCRIPTION
Have the qemu-plugin-sys crate's build script set link options that will allow downstream cdylibs to build without requiring the `unix-weak-link` feature.

This has a few benefits:
1. Works on macOS.
2. Doesn't use the `linkage` feature so a nightly complier isn't needed.
3. Won't accidentally use one of the weakly-linked symbols if there's a typo (although this could also be solved by putting `unimplemented!()` or `panic!()` into the weakly-linked versions).

Fixes: https://github.com/novafacing/qemu-rs/issues/27